### PR TITLE
Stop Ignoring Disabled

### DIFF
--- a/Radio.lua
+++ b/Radio.lua
@@ -101,6 +101,7 @@ return PseudoInstance:Register("Radio", {
 
 	Methods = {
 		SetChecked = Typer.AssignSignature(2, Typer.OptionalBoolean, function(self, Checked)
+			if self.Disabled then return true end
 			if Checked == nil then Checked = true end
 			local Changed = self.Checked == Checked == false
 


### PR DESCRIPTION
The Radio Element ignored the Disabled state, giving the user the ability to always select it even if it was disabled. This prevents from changing the state on click if the property Disabled is on true